### PR TITLE
Fixed moderator removal bug, fixed bug where new subreddits cant be added if none currently exist.

### DIFF
--- a/TheReposterminator/bot.py
+++ b/TheReposterminator/bot.py
@@ -101,7 +101,12 @@ class BotClient:
         """Runs the bot
         This function is entirely blocking, so any calls to other functions must
         be made prior to calling this."""
+        dm_check = True
         while True:
+            if dm_check and len(self.subreddits) < 1:
+                self.handle_dms()
+                dm_check = True
+            
             for sub in self.subreddits:
                 self.handle_dms()
                 if not sub.indexed:
@@ -238,7 +243,7 @@ class BotClient:
             if msg.body.startswith(('**gadzooks!', 'gadzooks!')) \
                     or 'invitation to moderate' in msg.subject:
                 self.accept_invite(msg)
-            elif "You have been removed as a moderator from " in msg.body:
+            elif "You have been removed as a moderator from " in msg.body and msg.subreddit != None:
                 self.handle_mod_removal(msg)
             msg.mark_read()
 

--- a/TheReposterminator/bot.py
+++ b/TheReposterminator/bot.py
@@ -101,11 +101,11 @@ class BotClient:
         """Runs the bot
         This function is entirely blocking, so any calls to other functions must
         be made prior to calling this."""
-        dm_check = True
+        initial_dm_check = True
         while True:
-            if dm_check and len(self.subreddits) < 1:
+            if initial_dm_check and len(self.subreddits) < 1:
                 self.handle_dms()
-                dm_check = True
+                initial_dm_check = False
             
             for sub in self.subreddits:
                 self.handle_dms()


### PR DESCRIPTION
Hi,
I fixed two issues with this that I noticed. 

1. I was unable to add any subreddits because I had none currently, and it wouldn't scan for new DMs as there were no subreddits to iterate over.
2. If someone sent the bot a message identical to the moderator removal message (or just the snip in the if clause), it would trigger a "removal" of /r/None as well as attempt to remove /r/None from the database. 

All in all, added an initial check for DMs and checked to verify the mod removal message is from a subreddit and not a user. On commit #2 I was renaming a variable to make more sense.